### PR TITLE
12-dockerise-notes-service-SETUP: Setup docker for notes-serice

### DIFF
--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  notes-service:
+    build:
+      context: ../../services/notes-service
+      dockerfile: ../../infra/docker/notes-service/Dockerfile
+    ports:
+      - "8080:8080"
+    container_name: notes-service

--- a/infra/docker/notes-service/Dockerfile
+++ b/infra/docker/notes-service/Dockerfile
@@ -1,0 +1,45 @@
+# -------------------------------------------
+# 🏗️ Stage 1: Build Stage
+# -------------------------------------------
+    
+FROM maven:3.9.10-eclipse-temurin-17 AS builder
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy Maven wrapper and pom.xml first for layer caching
+COPY .mvn/ .mvn
+COPY mvnw pom.xml ./
+
+# Download dependencies to speed up future builds
+RUN ./mvnw dependency:go-offline
+
+# Copy the rest of the source code
+COPY src ./src
+
+# Build the project JAR (skip tests during Docker build)
+RUN ./mvnw clean package -DskipTests
+
+# -------------------------------------------
+# 🚀 Stage 2: Runtime Stage
+# -------------------------------------------
+
+FROM eclipse-temurin:17-jre-jammy
+
+# Set the working directory for the app
+WORKDIR /app
+
+# 🛡️ Create a non-root user for running the app
+RUN addgroup --system spring && adduser --system --ingroup spring spring
+USER spring:spring
+
+# Copy only the built JAR from the builder stage
+# NOTE: Replace the wildcard if your JAR has a specific name
+COPY --from=builder /app/target/notes-service-0.0.1-SNAPSHOT.jar app.jar
+
+# Inform Docker what port the container exposes (optional)
+EXPOSE 8080
+
+# Default command to run the Spring Boot app
+ENTRYPOINT ["java", "-jar", "app.jar"]
+    

--- a/services/notes-service/.dockerignore
+++ b/services/notes-service/.dockerignore
@@ -1,0 +1,9 @@
+target/
+.git/
+.gitignore
+README.md
+.idea/
+.vscode/
+*.iml
+*.log
+.DS_Store

--- a/services/notes-service/README.md
+++ b/services/notes-service/README.md
@@ -1,0 +1,71 @@
+# Notes Service
+
+The Notes Service is a microservice within the Project Task Hub monorepo. It is responsible for creating, reading, updating, and deleting notes.
+
+## Tech Stack
+
+- Framework: Spring Boot 3.x
+- Language: Java 17
+- Build Tool: Maven
+- Containerized: Docker (Multistage)
+- Orchestrated With: Docker Compose
+
+## Getting Started
+
+### Prerequisites
+
+- JDK 17 or higher
+- Maven (or use the included Maven Wrapper)
+- Docker and Docker Compose
+
+### Running with Maven
+
+```bash
+cd services/notes-service
+./mvnw spring-boot:run  # On Windows use .\mvnw spring-boot:run
+```
+
+The service will be available at: [http://localhost:8080](http://localhost:8080)
+
+### Running with Docker Compose
+
+```bash
+cd path/to/project-task-hub
+docker-compose -f infra/docker/docker-compose.yml up --build notes-service
+```
+
+## Building and Testing
+
+### Building the JAR
+
+```bash
+cd services/notes-service
+./mvnw clean package -DskipTests
+```
+
+The JAR file will be located in the `target/` directory.
+
+### Running Tests
+
+```bash
+./mvnw test
+```
+
+## API Endpoints
+
+### Health Check
+
+- Method: GET
+- URL: `/api/notes/hello`
+- Description: Simple endpoint to verify that the service is running.
+- Example Response:
+
+```json
+{
+  "message": "Hello from Notes Service!"
+}
+```
+
+## Project Folder: `services/notes-service/`
+
+This folder contains all Spring Boot application source code and is containerized using a Dockerfile located under `infra/docker/notes-service/`.


### PR DESCRIPTION
This pull request introduces a new microservice, the Notes Service, to the Project Task Hub monorepo. The changes include adding Docker support for containerization and orchestration, a `.dockerignore` file for optimized builds, and comprehensive documentation for setup and usage.

### Dockerization and Orchestration:
* Added a `docker-compose.yml` file to define the Notes Service container, exposing it on port 8080.
* Created a multistage `Dockerfile` for the Notes Service to build and run the Spring Boot application efficiently.

### Build Optimization:
* Introduced a `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, improving build performance.

### Documentation:
* Added a `README.md` file for the Notes Service, detailing its purpose, tech stack, prerequisites, setup instructions, and API endpoints.